### PR TITLE
Исправлено позиционирование метки на карте

### DIFF
--- a/angular-ymaps.js
+++ b/angular-ymaps.js
@@ -143,8 +143,8 @@ angular.module('ymaps', [])
             var marker;
             function pickMarker() {
                 var coord = [
-                    parseInt($scope.coordinates[0], 10),
-                    parseInt($scope.coordinates[1], 10)
+                    parseFloat($scope.coordinates[0]),
+                    parseFloat($scope.coordinates[1])
                 ];
                 if (marker) {
                     marker.geometry.setCoordinates(coord);


### PR DESCRIPTION
Из-за parseInt обрезалась вся дробная часть и метки позиционировались только по целой части
